### PR TITLE
Add Compare Expressions

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -25,6 +25,8 @@ pub enum Expr {
     Or(Box<Expr>, Box<Expr>),
     Xor(Box<Expr>, Box<Expr>),
     Not(Box<Expr>),
+    Equal(Box<Expr>, Box<Expr>),
+    Less(Box<Expr>, Box<Expr>),
     Arrayed(Vec<Expr>),
     Blocked(Box<Config>),
     AsCast(Box<Expr>, Typing),
@@ -305,6 +307,10 @@ mod test_expr {
                 ),
                 ""
             ))
+        );
+        assert_eq!(
+            expr().parse("not not(true)"),
+            Ok((Not(Box::new(Not(Box::new(Val(Bool(true)))))), ""))
         );
     }
 


### PR DESCRIPTION
Expression has the following hierarchy.

- Expression
    - Various containing Logic Expression
- Logic Expression
    - Exact 1 Bool Expression, or `==` `!=` `<=` `>=` `<` `>` of 2 Bool Expressions
- Bool Expression
    - Exact 1 Arith Expression, or `and` `or` `xor` of 2 Arith Expressions
- Arith Expression
    - `+` `-` of Terms
- Term
    - `*` `/` of Factors
- Factor
    - `-x` `not x` `( Expression )` where `x` is Value.